### PR TITLE
Retar COVID-19 data with GNU tar

### DIFF
--- a/datasets.json
+++ b/datasets.json
@@ -3,7 +3,7 @@
     "hydro": { "filename": "hydro_data.tar.bz2", "last_updated": "2023-03-01" },
     "covid": {
       "filename": "covid19_data.tar.bz2",
-      "last_updated": "2023-03-01"
+      "last_updated": "2024-03-19"
     },
     "covid_mcmc": {
       "filename": "covid19_data2.tar.bz2",


### PR DESCRIPTION
I re-tared the COVID-19 data with GNU tar to see if that fixes issue #11 that may have been caused by an encoding issue.